### PR TITLE
Link logo to AnonAddy homepage

### DIFF
--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -41,7 +41,7 @@
                             @endif
                         </div>
 
-                        <div class="flex flex-wrap mb-6">
+                        <div class="flex flex-wrap mb-2">
                             <label for="password" class="block text-grey-700 text-sm mb-2">
                                 {{ __('Password') }}:
                             </label>
@@ -55,15 +55,15 @@
                             @endif
                         </div>
 
-                        <div class="flex justify-between">
-                            <div>
+                        <div class="flex flex-wrap justify-between items-center">
+                            <div class="mr-5 mt-4">
                                 <input type="checkbox" name="remember" id="remember" {{ old('remember') ? 'checked' : '' }}>
                                 <label class="text-sm text-grey-700 ml-3" for="remember">
                                     {{ __('Remember Me') }}
                                 </label>
                             </div>
                             @if (Route::has('password.request'))
-                                <a class="whitespace-nowrap no-underline text-sm" href="{{ route('password.request') }}">
+                                <a class="whitespace-nowrap no-underline text-sm mt-4" href="{{ route('password.request') }}">
                                     {{ __('Forgot Username/Password?') }}
                                 </a>
                             @endif

--- a/resources/views/auth/login.blade.php
+++ b/resources/views/auth/login.blade.php
@@ -5,7 +5,9 @@
         <div class="w-full max-w-md">
 
             <div class="flex justify-center text-white mb-6 text-5xl font-bold">
-                <img class="w-48" alt="AnonAddy Logo" src="/svg/logo.svg">
+                <a href="https://anonaddy.com" aria-label="Go to Anonaddy homepage">
+                    <img class="w-48" alt="AnonAddy Logo" src="/svg/logo.svg">
+                </a>
             </div>
             <div class="flex flex-col break-words bg-white border border-2 rounded-lg shadow-lg overflow-hidden">
                 <form class="" method="POST" action="{{ route('login') }}">


### PR DESCRIPTION
This PR includes 2 changes to the login page:

- Link logo to the AnonAddy homepage
- Fix responsive behaviour reset password link

## Before:
Responsive behaviour:
![image](https://user-images.githubusercontent.com/11559216/111919842-3ee23a00-8a8c-11eb-9268-5ea3e75cec55.png)

(Minor) misalignment of remember me and request new pw link:
![image](https://user-images.githubusercontent.com/11559216/111919910-7bae3100-8a8c-11eb-834d-e903b7e84d63.png)


## After:
![image](https://user-images.githubusercontent.com/11559216/111919789-02aed980-8a8c-11eb-8ae5-e0680d7a76bc.png)
![image](https://user-images.githubusercontent.com/11559216/111919895-6fc26f00-8a8c-11eb-917f-b71c1b3508a7.png)
