### PR TITLE
add option `hostname` to create alias API endpoint

### DIFF
--- a/app/Http/Controllers/Api/AliasController.php
+++ b/app/Http/Controllers/Api/AliasController.php
@@ -67,8 +67,11 @@ class AliasController extends Controller
             return response('You have reached your hourly limit for creating new aliases', 429);
         }
 
-        $formatEmail = function(string $localPart, string $domain, string $prefix = '') {
-            return $prefix . '.' . $localPart . '@' . $domain;
+        $formatEmail = function(string $localPart, string $domain, string $prefix) {
+            if (isset($prefix) {
+                $localPart = $prefix . '.' . $localPart;
+            }
+            return $localPart . '@' . $domain;
         };
 
         if (isset($request->validated()['local_part'])) {

--- a/app/Http/Requests/StoreAliasRequest.php
+++ b/app/Http/Requests/StoreAliasRequest.php
@@ -39,7 +39,8 @@ class StoreAliasRequest extends FormRequest
                 'array',
                 'max:10',
                 new VerifiedRecipientId
-            ]
+            ],
+            'hostname' => 'nullable|string|max:100'
         ];
     }
 

--- a/composer.json
+++ b/composer.json
@@ -14,6 +14,7 @@
         "fideloper/proxy": "^4.2",
         "fruitcake/laravel-cors": "^2.0",
         "guzzlehttp/guzzle": "^7.0.1",
+        "jeremykendall/php-domain-parser": "^6.1",
         "laravel/framework": "^8.0",
         "laravel/passport": "^10.0",
         "laravel/tinker": "^2.0",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "f7a28b5a628118a9e98cc2c118e93415",
+    "content-hash": "1335a8511503e6e1ac2df759dbeb3321",
     "packages": [
         {
             "name": "asbiin/laravel-webauthn",
@@ -1950,6 +1950,101 @@
                 }
             ],
             "time": "2022-05-21T17:30:32+00:00"
+        },
+        {
+            "name": "jeremykendall/php-domain-parser",
+            "version": "6.1.1",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/jeremykendall/php-domain-parser.git",
+                "reference": "e195ab7bf0dd0ca231e066790fb0771f1acba5f1"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/jeremykendall/php-domain-parser/zipball/e195ab7bf0dd0ca231e066790fb0771f1acba5f1",
+                "reference": "e195ab7bf0dd0ca231e066790fb0771f1acba5f1",
+                "shasum": ""
+            },
+            "require": {
+                "ext-filter": "*",
+                "ext-intl": "*",
+                "ext-json": "*",
+                "php": "^7.4 || ^8.0"
+            },
+            "require-dev": {
+                "friendsofphp/php-cs-fixer": "^v3.5.0",
+                "guzzlehttp/guzzle": "^7.0",
+                "guzzlehttp/psr7": "^1.6||^2.0",
+                "phpstan/phpstan": "^1.4.6.",
+                "phpstan/phpstan-phpunit": "^1.0.0",
+                "phpstan/phpstan-strict-rules": "^1.1.0",
+                "phpunit/phpunit": "^9.5.13",
+                "psalm/plugin-phpunit": "^0.15.2",
+                "psr/http-factory": "^1.0",
+                "psr/simple-cache": "^1.0",
+                "symfony/cache": "^v5.0",
+                "vimeo/psalm": "^4.20"
+            },
+            "suggest": {
+                "league/uri": "To parse URL and validate host",
+                "psr/http-client-implementation": "To use the storage functionnality which depends on PSR-18",
+                "psr/http-factory-implementation": "To use the storage functionnality which depends on PSR-17",
+                "psr/simple-cache-implementation": "To use the storage functionnality which depends on PSR-16"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "6.x-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Pdp\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Jeremy Kendall",
+                    "homepage": "http://about.me/jeremykendall",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Ignace Nyamagana Butera",
+                    "homepage": "http://nyamsprod.com",
+                    "role": "Developer"
+                },
+                {
+                    "name": "Contributors",
+                    "homepage": "https://github.com/jeremykendall/php-domain-parser/graphs/contributors"
+                }
+            ],
+            "description": "Public Suffix List and IANA Root Zone Database based Domain parsing implemented in PHP.",
+            "homepage": "https://github.com/jeremykendall/php-domain-parser",
+            "keywords": [
+                "PSL",
+                "Public Suffix List",
+                "Top Level Domains",
+                "domain parsing",
+                "iana",
+                "icann",
+                "idn",
+                "tld"
+            ],
+            "support": {
+                "issues": "https://github.com/jeremykendall/php-domain-parser/issues",
+                "source": "https://github.com/jeremykendall/php-domain-parser"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/sponsors/nyamsprod",
+                    "type": "github"
+                }
+            ],
+            "time": "2022-02-18T22:00:34+00:00"
         },
         {
             "name": "laravel/framework",
@@ -12223,5 +12318,5 @@
         "php": "^7.3|^8.0"
     },
     "platform-dev": [],
-    "plugin-api-version": "2.2.0"
+    "plugin-api-version": "2.3.0"
 }

--- a/config/version.yml
+++ b/config/version.yml
@@ -5,9 +5,9 @@ current:
   major: 0
   minor: 11
   patch: 2
-  prerelease: 3-ga4fd2df
+  prerelease: 4-g59522f7
   buildmetadata: ''
-  commit: a4fd2d
+  commit: 59522f
   timestamp:
     year: 2020
     month: 10


### PR DESCRIPTION
Hey there,

Thanks for all the work on this very helpful service.

I've attempted (first time using PHP so might have missed some things, mainly having trouble with the PHP and composer installed in Codespaces) to add a new `hostname` field to the `POST api/v1/aliases` endpoint. The idea being that the main part of the domain name can be prepended to the alias (e.g. `anonaddy.zxcvbn123@uname.anonaddy.me`).

The goal I had in mind is to use this with the Bitwarden extension to automatically include the website name in the alias if desired. [Example of how it's done in their extension](https://github.com/bitwarden/clients/blob/da5e4a57d026e0d09356ad3405e08fb140462fd7/libs/common/src/services/usernameGeneration.service.ts#L187).

PS: are there any steps for contributing that I might have missed, or is it just a case of following the `SELF-HOSTING.md` file mainly?