### PR TITLE
fix v-clipboard version

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
         "resolve-url-loader": "^5.0.0",
         "tailwindcss": "^3.0.11",
         "tippy.js": "^6.2.7",
-        "v-clipboard": "github:euvl/v-clipboard",
+        "v-clipboard": "^2.2.3",
         "vue": "^3.0.0",
         "vue-good-table-next": "^0.2.1",
         "vue-loader": "^17.0.0",


### PR DESCRIPTION
anonaddy is using a clipboard plugin called `v-clipboard`, which recently got upgraded to v3.0.0-next.1.
When trying to self host anonaddy, the user will get the following error message:
```
ERROR in ./resources/js/app.js 10:0-46
Module not found: Error: Package path ./src/index is not exported from package /var/www/anonaddy/node_modules/v-clipboard (see exports field in /var/www/anonaddy/node_modules/v-clipboard/package.json)
```
A simple fix is to change `"v-clipboard": "github:euvl/v-clipboard"` to `"v-clipboard": "^2.2.3"`.