### PR TITLE
Width of rule modals increased

### DIFF
--- a/resources/js/pages/Rules.vue
+++ b/resources/js/pages/Rules.vue
@@ -78,7 +78,7 @@
       </div>
     </div>
 
-    <Modal :open="createRuleModalOpen" @close="createRuleModalOpen = false" :overflow="true">
+    <Modal :open="createRuleModalOpen" @close="createRuleModalOpen = false" :overflow="true" :maxWidth="'sm:max-w-2xl'">
       <template v-slot:title> Create new rule </template>
       <template v-slot:content>
         <p class="mt-4 text-grey-700">
@@ -446,7 +446,7 @@
       </template>
     </Modal>
 
-    <Modal :open="editRuleModalOpen" @close="closeEditModal" :overflow="true">
+    <Modal :open="editRuleModalOpen" @close="closeEditModal" :overflow="true" :maxWidth="'sm:max-w-2xl'">
       <template v-slot:title> Edit rule </template>
       <template v-slot:content>
         <p class="mt-4 text-grey-700">


### PR DESCRIPTION
The modals for creating and editing rules were too narrow.

**Before:**
![before](https://user-images.githubusercontent.com/789788/212482894-bb4a6e3c-7a9f-4c02-813a-d2f6f23b39f2.png)

**After:**
![after](https://user-images.githubusercontent.com/789788/212482898-0f453bd6-281b-48a2-8d85-75673d865f2e.png)
