### PR TITLE
Proxy authentication support (eq. oauth2-proxy)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -63,3 +63,10 @@ ANONADDY_SIGNING_KEY_FINGERPRINT=
 # This is only needed if you will be adding any custom domains. If you do not need it then leave it blank. ANONADDY_DKIM_SIGNING_KEY=/etc/opendkim/keys/example.com/default.private
 ANONADDY_DKIM_SIGNING_KEY=
 ANONADDY_DKIM_SELECTOR=default
+
+# This allows an reverse proxy (e.q. OAuth2-Proxy or Authentik Proxy Provider) to send the username and email to automatically login 
+# Make sure to only set this to true when using an (trusted) reverse proxy
+# Use `ANONADDY_PROXY_AUTHENTICATION_NAME_HEADER` `ANONADDY_PROXY_AUTHENTICATION_EMAIL_HEADER` to change the headers to be used
+ANONADDY_USE_PROXY_AUTHENTICATION=false
+ANONADDY_PROXY_AUTHENTICATION_NAME_HEADER=X-Name
+ANONADDY_PROXY_AUTHENTICATION_EMAIL_HEADER=X-Email

--- a/app/Helpers/Helper.php
+++ b/app/Helpers/Helper.php
@@ -52,14 +52,19 @@ function stripEmailExtension(string $email): string
      *
      * @return \App\Models\User
      */
-function createUser(string $username, string $email, string|null $password = null) 
+function createUser(string $username, string $email, string|null $password = null, bool $emailVerified = false) 
 {
     $userId = Uuid::uuid4();
 
     $recipient = Recipient::create([
         'email' => $email,
-        'user_id' => $userId,
+        'user_id' => $userId,    
     ]);
+
+    if ($emailVerified)
+    {
+        $recipient->markEmailAsVerified();    
+    }
 
     $usernameModel = Username::create([
         'username' => $username,

--- a/app/Http/Controllers/Auth/LoginController.php
+++ b/app/Http/Controllers/Auth/LoginController.php
@@ -2,7 +2,6 @@
 
 namespace App\Http\Controllers\Auth;
 
-use App\Enums\LoginRedirect;
 use App\Http\Controllers\Controller;
 use App\Models\Username;
 use Illuminate\Foundation\Auth\AuthenticatesUsers;
@@ -41,18 +40,6 @@ class LoginController extends Controller
     public function __construct()
     {
         $this->middleware('guest')->except('logout');
-    }
-
-    public function redirectTo()
-    {
-        // Dynamic redirect setting to allow users to choose to go to /aliases page instead etc.
-        return match (user()->login_redirect) {
-            LoginRedirect::ALIASES => '/aliases',
-            LoginRedirect::RECIPIENTS => '/recipients',
-            LoginRedirect::USERNAMES => '/usernames',
-            LoginRedirect::DOMAINS => '/domains',
-            default => '/',
-        };
     }
 
     public function username()
@@ -115,11 +102,7 @@ class LoginController extends Controller
             return $response;
         }
 
-        // If the intended path is just the dashboard then ignore and use the user's login redirect instead
-        $redirectTo = $this->redirectTo();
-        $intended = session()->pull('url.intended');
-
-        return $intended === url('/') ? redirect()->to($redirectTo) : redirect()->intended($intended ?? $redirectTo);
+        return getLoginRedirectResponse();
     }
 
     /**

--- a/app/Http/Controllers/Auth/RegisterController.php
+++ b/app/Http/Controllers/Auth/RegisterController.php
@@ -3,19 +3,16 @@
 namespace App\Http\Controllers\Auth;
 
 use App\Http\Controllers\Controller;
-use App\Models\Recipient;
 use App\Models\User;
-use App\Models\Username;
 use App\Rules\NotBlacklisted;
 use App\Rules\NotDeletedUsername;
 use App\Rules\NotLocalRecipient;
 use App\Rules\RegisterUniqueRecipient;
 use Illuminate\Foundation\Auth\RegistersUsers;
 use Illuminate\Support\Facades\App;
-use Illuminate\Support\Facades\Hash;
 use Illuminate\Support\Facades\Validator;
 use Illuminate\Validation\Rules\Password;
-use Ramsey\Uuid\Uuid;
+
 
 class RegisterController extends Controller
 {
@@ -104,26 +101,6 @@ class RegisterController extends Controller
      */
     protected function create(array $data)
     {
-        $userId = Uuid::uuid4();
-
-        $recipient = Recipient::create([
-            'email' => $data['email'],
-            'user_id' => $userId,
-        ]);
-
-        $username = Username::create([
-            'username' => $data['username'],
-            'user_id' => $userId,
-        ]);
-
-        $twoFactor = app('pragmarx.google2fa');
-
-        return User::create([
-            'id' => $userId,
-            'default_username_id' => $username->id,
-            'default_recipient_id' => $recipient->id,
-            'password' => Hash::make($data['password']),
-            'two_factor_secret' => $twoFactor->generateSecretKey(),
-        ]);
+        return createUser($data['username'], $data['email'], $data['password']);
     }
 }

--- a/app/Http/Middleware/ProxyAuthentication.php
+++ b/app/Http/Middleware/ProxyAuthentication.php
@@ -60,7 +60,7 @@ class ProxyAuthentication
         }
         if ($loggedOut)
         {
-            return redirect('/');
+            return redirect('/login');
         }
 
         return $next($request);

--- a/app/Http/Middleware/ProxyAuthentication.php
+++ b/app/Http/Middleware/ProxyAuthentication.php
@@ -1,0 +1,90 @@
+<?php
+
+namespace App\Http\Middleware;
+
+use Closure;
+use App\Models\Username;
+use Illuminate\Contracts\Auth\Factory as AuthFactory;
+use Illuminate\Session\Middleware\AuthenticateSession;
+use Illuminate\Http\Request;
+use Illuminate\Support\Facades\Auth;
+use Symfony\Component\HttpFoundation\Response;
+
+
+class ProxyAuthentication extends AuthenticateSession 
+{
+    private bool $isProxyAuthenticationEnabled;
+    private string $usernameHeaderName;
+    private string $emailHeaderName;
+
+
+    /**
+     * Create a new instance.
+     *
+     * @return void
+     */
+    public function __construct(AuthFactory  $auth)
+    {
+        $this->isProxyAuthenticationEnabled = config('anonaddy.use_proxy_authentication');
+        $this->usernameHeaderName = config('anonaddy.proxy_authentication_username_header');
+        $this->emailHeaderName = config('anonaddy.proxy_authentication_email_header');
+        parent::__construct($auth);
+    }
+
+
+    /**
+     * Handle an incoming request.
+     *
+     * @param  \Closure(\Illuminate\Http\Request): (\Symfony\Component\HttpFoundation\Response)  $next
+     */
+    public function handle($request, Closure $next)
+    {
+        if (!Auth::check() && $request != null && $this->isProxyAuthenticationEnabled)
+        {
+            $this->handleProxyAuthentication($request);
+            return tap($next($request), function () use ($request) {
+                $this->handleProxyAuthentication($request);
+            });
+        }
+        else
+        {
+            return parent::handle($request, $next);
+        }
+    }
+
+    private function handleProxyAuthentication(Request $request)
+    {
+        $username = $request->header($this->usernameHeaderName);
+        $email = $request->header($this->emailHeaderName);
+
+        if ($this->isNullOrEmptyString($username) || $this->isNullOrEmptyString($email))
+        {
+            abort(401);
+        }
+
+        $usernameModel = Username::select(['user_id', 'username', 'can_login'])
+            ->where('username', $username)
+            ->first();
+
+        if ($usernameModel !== null && $usernameModel->can_login === false)
+        {
+            abort(401);
+        }
+
+        if ($usernameModel === null)
+        {
+            $userId = createUser($username, $email)->id;
+        }
+        else
+        {
+            $userId = $usernameModel->user_id;
+        }
+
+        Auth::loginUsingId($userId);
+        $request->session()->regenerate();
+    }
+
+    private function isNullOrEmptyString(string|null $str){
+        return $str === null || trim($str) === '';
+    }
+}

--- a/app/Http/Middleware/ProxyAuthentication.php
+++ b/app/Http/Middleware/ProxyAuthentication.php
@@ -51,8 +51,8 @@ class ProxyAuthentication
         $username = $request->header($this->usernameHeaderName);
         $email = $request->header($this->emailHeaderName);
         
-        $loggedOut = $this->LogoutWhenNeeded($request, $loggedInUsername, $username);
-        $loggedIn = $this->LoginWhenNeeded($request, $username, $email);
+        $loggedOut = $this->logoutWhenNeeded($request, $loggedInUsername, $username);
+        $loggedIn = $this->loginWhenNeeded($request, $username, $email);
         
         if ($loggedIn)
         {
@@ -66,7 +66,7 @@ class ProxyAuthentication
         return $next($request);
     }
 
-    private function LogoutWhenNeeded(Request $request, string|null $loggedInUsername, string|null $username) : bool
+    private function logoutWhenNeeded(Request $request, string|null $loggedInUsername, string|null $username) : bool
     {
         if (Auth::check())
         {
@@ -87,7 +87,7 @@ class ProxyAuthentication
         return false;
     }
 
-    private function LoginWhenNeeded(Request $request, string|null $username, string|null $email) : bool
+    private function loginWhenNeeded(Request $request, string|null $username, string|null $email) : bool
     {
         $notloggedInButHeadersProvided = !Auth::check() && !$this->isNullOrEmptyString($username) && !$this->isNullOrEmptyString($email);
         if ($notloggedInButHeadersProvided)

--- a/app/Http/Middleware/ProxyAuthentication.php
+++ b/app/Http/Middleware/ProxyAuthentication.php
@@ -109,11 +109,11 @@ class ProxyAuthentication
 
     private function getValidUserIdForUsername(string $username) : string|null
     {
-        $usernameModel = Username::select(['user_id', 'username', 'can_login'])
+        $usernameModel = Username::select(['user_id', 'username', 'can_login', 'active'])
             ->where('username', $username)
             ->first();
 
-        if ($usernameModel !== null && $usernameModel->can_login === false)
+        if ($usernameModel !== null && ($usernameModel->can_login === false || $usernameModel->active === false))
         {
             abort(401);
         } 

--- a/app/Http/Middleware/ProxyAuthentication.php
+++ b/app/Http/Middleware/ProxyAuthentication.php
@@ -9,6 +9,7 @@ use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
 
+
 class ProxyAuthentication
 {
     private const proxyAuthenticationUsernameSessionKey = 'ProxyAuthenticationUsername';
@@ -53,7 +54,11 @@ class ProxyAuthentication
         $loggedOut = $this->LogoutWhenNeeded($request, $loggedInUsername, $username);
         $loggedIn = $this->LoginWhenNeeded($request, $username, $email);
         
-        if ($loggedOut || $loggedIn)
+        if ($loggedIn)
+        {
+            return getLoginRedirectResponse();
+        }
+        if ($loggedOut)
         {
             return redirect('/');
         }
@@ -74,8 +79,7 @@ class ProxyAuthentication
                 $loggedinFromProxyButUsernameDoesNotMatch)
             {
                 Auth::logout();
-                $request->session()->regenerate();
-                $request->session()->forget(self::proxyAuthenticationUsernameSessionKey);
+                $request->session()->flush();
                 return true;
             }
         }

--- a/app/Http/Middleware/SessionWithProxyAuthentication.php
+++ b/app/Http/Middleware/SessionWithProxyAuthentication.php
@@ -94,7 +94,7 @@ class SessionWithProxyAuthentication extends AuthenticateSession
             $userId = $this->getValidUserIdForUsername($username);
             if ($userId === null)
             {
-                $userId = createUser($username, $email)->id;
+                $userId = createUser($username, $email, emailVerified: true)->id;
             }
 
             Auth::loginUsingId($userId);

--- a/app/Http/Middleware/SessionWithProxyAuthentication.php
+++ b/app/Http/Middleware/SessionWithProxyAuthentication.php
@@ -11,7 +11,7 @@ use Illuminate\Support\Facades\Auth;
 use Symfony\Component\HttpFoundation\Response;
 
 
-class ProxyAuthentication extends AuthenticateSession 
+class SessionWithProxyAuthentication extends AuthenticateSession 
 {
     private bool $isProxyAuthenticationEnabled;
     private string $usernameHeaderName;

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,7 +3,6 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
-use Illuminate\Session\Middleware\AuthenticateSession;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -36,8 +36,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->web(append: [
             \App\Http\MiddleWare\ProxyAuthentication::class,
             \App\Http\Middleware\HandleInertiaRequests::class, // Must be the last item!
-            ]
-        );
+        ]);
 
         $middleware->alias([
             '2fa' => \App\Http\Middleware\VerifyTwoFactorAuth::class,

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -34,12 +34,10 @@ return Application::configure(basePath: dirname(__DIR__))
         );
 
         $middleware->web(append: [
+            \App\Http\MiddleWare\ProxyAuthentication::class,
             \App\Http\Middleware\HandleInertiaRequests::class, // Must be the last item!
-        ], replace: [
-            'auth.session' => \App\Http\MiddleWare\SessionWithProxyAuthentication::class
-        ],
-    
-    );
+            ]
+        );
 
         $middleware->alias([
             '2fa' => \App\Http\Middleware\VerifyTwoFactorAuth::class,

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -36,7 +36,7 @@ return Application::configure(basePath: dirname(__DIR__))
         $middleware->web(append: [
             \App\Http\Middleware\HandleInertiaRequests::class, // Must be the last item!
         ], replace: [
-            'auth.session' => \App\Http\MiddleWare\ProxyAuthentication::class
+            'auth.session' => \App\Http\MiddleWare\SessionWithProxyAuthentication::class
         ],
     
     );

--- a/bootstrap/app.php
+++ b/bootstrap/app.php
@@ -3,6 +3,7 @@
 use Illuminate\Foundation\Application;
 use Illuminate\Foundation\Configuration\Exceptions;
 use Illuminate\Foundation\Configuration\Middleware;
+use Illuminate\Session\Middleware\AuthenticateSession;
 
 return Application::configure(basePath: dirname(__DIR__))
     ->withRouting(
@@ -34,7 +35,11 @@ return Application::configure(basePath: dirname(__DIR__))
 
         $middleware->web(append: [
             \App\Http\Middleware\HandleInertiaRequests::class, // Must be the last item!
-        ]);
+        ], replace: [
+            'auth.session' => \App\Http\MiddleWare\ProxyAuthentication::class
+        ],
+    
+    );
 
         $middleware->alias([
             '2fa' => \App\Http\Middleware\VerifyTwoFactorAuth::class,

--- a/config/anonaddy.php
+++ b/config/anonaddy.php
@@ -216,6 +216,37 @@ return [
 
     /*
     |--------------------------------------------------------------------------
+    | Use Proxy authentication
+    |--------------------------------------------------------------------------
+    |
+    | If enabled, a proxy can add a X-Name (header name specified down below) to the request and auto login or register
+    | Make sure to only set this when behind a trusted proxy to prevent malicious 
+    |
+    */
+    'use_proxy_authentication' => env('ANONADDY_USE_PROXY_AUTHENTICATION', false),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Proxy authentication X-Name header
+    |--------------------------------------------------------------------------
+    |
+    | Header name for the username that the Proxy authentication uses to authenticate
+    |
+    */
+    'proxy_authentication_username_header' => env('ANONADDY_PROXY_AUTHENTICATION_NAME_HEADER', 'X-Name'),
+
+    /*
+    |--------------------------------------------------------------------------
+    | Proxy authentication X-Email header
+    |--------------------------------------------------------------------------
+    |
+    | Header name for the email that the Proxy authentication uses
+    |
+    */
+    'proxy_authentication_email_header' => env('ANONADDY_PROXY_AUTHENTICATION_EMAIL_HEADER', 'X-Email'),
+
+    /*
+    |--------------------------------------------------------------------------
     | Username Blacklist
     |--------------------------------------------------------------------------
     |

--- a/tests/Feature/ProxyAuthenticationTest.php
+++ b/tests/Feature/ProxyAuthenticationTest.php
@@ -145,4 +145,44 @@ class ProxyAuthenticationTest extends TestCase
             ->assertRedirect('/aliases')
             ->assertSessionHasNoErrors();
     }
+
+    #[Test]
+    public function unauthenticated_when_user_with_proxy_headers_cannot_login()
+    {
+        $userBar = $this->createUser('bar', null); 
+        $username = Username::where('username', 'bar')->first();
+        $username->disallowLogin();
+        $username->save();
+
+        
+        $response = $this
+            ->withHeaders([
+                'X-Name' => 'bar',
+                'X-Email' => 'bar@foo.com'
+            ])
+            ->get('/login');
+
+        $response
+            ->assertStatus(401);
+    }
+
+    #[Test]
+    public function unauthenticated_when_user_with_proxy_headers_deactivated()
+    {
+        $userBar = $this->createUser('bar', null); 
+        $username = Username::where('username', 'bar')->first();
+        $username->deactivate();
+        $username->save();
+
+        
+        $response = $this
+            ->withHeaders([
+                'X-Name' => 'bar',
+                'X-Email' => 'bar@foo.com'
+            ])
+            ->get('/login');
+
+        $response
+            ->assertStatus(401);
+    }
 }

--- a/tests/Feature/ProxyAuthenticationTest.php
+++ b/tests/Feature/ProxyAuthenticationTest.php
@@ -1,0 +1,148 @@
+<?php
+
+namespace Tests\Feature;
+
+use App\Enums\LoginRedirect;
+use App\Models\Username;
+use Illuminate\Foundation\Testing\LazilyRefreshDatabase;
+use Illuminate\Routing\Middleware\ThrottleRequestsWithRedis;
+use Illuminate\Support\Facades\Config;
+use Illuminate\Support\Facades\Hash;
+use Illuminate\Support\Str;
+use PHPUnit\Framework\Attributes\Test;
+use Tests\TestCase;
+
+class ProxyAuthenticationTest extends TestCase
+{
+    use LazilyRefreshDatabase;
+
+    protected $userJohnDoe;
+    protected $userJaneDoe;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        Config::set('anonaddy.use_proxy_authentication', true);
+        Config::set('anonaddy.proxy_authentication_username_header', 'X-Name');
+        Config::set('anonaddy.proxy_authentication_email_header', 'X-Email');
+
+        $this->userJohnDoe = $this->createUser('johndoe', null, ['password' => Hash::make('mypassword')]);
+        $this->userJaneDoe = $this->createUser('janedoe', null);    
+    }
+
+    #[Test]
+    public function user_can_login_with_proxy_headers()
+    {
+        $response = $this->withHeaders([
+            'X-Name' => 'janedoe',
+            'X-Email' => 'jane@doe.com'
+        ])->get('/login');
+
+        $response
+            ->assertRedirect('/')
+            ->assertSessionHasNoErrors()
+            ->assertSessionHas('ProxyAuthenticationUsername');     
+
+        $this->assertAuthenticatedAs($this->userJaneDoe, $guard = null);
+    }
+
+    #[Test]
+    public function user_can_register_with_proxy_headers()
+    {
+        $response = $this->withHeaders([
+            'X-Name' => 'foo',
+            'X-Email' => 'foo@bar.com'
+        ])->get('/login');
+
+        $response
+            ->assertRedirect('/')
+            ->assertSessionHasNoErrors()
+            ->assertSessionHas('ProxyAuthenticationUsername');
+
+        $this->assertDatabaseHas('usernames', [
+            'username' => 'foo',
+        ]);
+
+        $username = Username::where('username', 'foo')->first();
+
+        $this->assertThat($username->can_login, $this->isTrue(), 'username can login');
+        $this->assertThat($username->user->defaultRecipient->hasVerifiedEmail(), $this->isTrue(), 'Verified email');
+    }
+
+    #[Test]
+    public function user_logged_in_with_proxy_headers_logged_out_when_proxy_headers_removed()
+    {
+        $response = $this
+            ->actingAs($this->userJaneDoe)
+            ->withSession(['ProxyAuthenticationUsername' => 'janedoe'])
+            ->withHeaders([])
+            ->get('/');
+
+        $response
+            ->assertRedirect('/login')
+            ->assertSessionHasNoErrors()
+            ->assertSessionMissing('ProxyAuthenticationUsername');
+
+        $this->assertGuest($guard = null);
+    }
+
+    #[Test]
+    public function currently_normal_logged_in_user_logged_out_when_user_with_proxy_headers_provided()
+    {
+        $response = $this
+            ->actingAs($this->userJohnDoe)
+            ->withHeaders([
+                'X-Name' => 'janedoe',
+                'X-Email' => 'jane@doe.com'
+            ])
+            ->get('/');
+
+        $response
+            ->assertSessionHasNoErrors()
+            ->assertSessionHas('ProxyAuthenticationUsername'); 
+
+        $this->assertAuthenticatedAs($this->userJaneDoe, $guard = null);
+    }
+
+    #[Test]
+    public function user_logged_in_when_proxy_headers_switched()
+    {
+        $userBar = $this->createUser('bar', null);   
+
+        $response = $this
+            ->actingAs($userBar)
+            ->withSession(['ProxyAuthenticationUsername' => 'bar'])
+            ->withHeaders([
+                'X-Name' => 'janedoe',
+                'X-Email' => 'jane@doe.com'
+            ])
+            ->get('/');
+
+        $response
+        ->assertSessionHasNoErrors()
+        ->assertSessionHas('ProxyAuthenticationUsername'); 
+
+        $this->assertAuthenticatedAs($this->userJaneDoe, $guard = null);
+    }
+
+    #[Test]
+    public function user_can_login_with_proxy_headers_and_be_redirected_based_on_login_redirect_successfully()
+    {
+        $this->withoutMiddleware(ThrottleRequestsWithRedis::class);
+
+        $this->userJaneDoe->login_redirect = LoginRedirect::ALIASES;
+        $this->userJaneDoe->save();
+
+        $response = $this
+            ->withHeaders([
+                'X-Name' => 'janedoe',
+                'X-Email' => 'jane@doe.com'
+            ])
+            ->get('/login');
+
+        $response
+            ->assertRedirect('/aliases')
+            ->assertSessionHasNoErrors();
+    }
+}


### PR DESCRIPTION
**Introduction**
When searching for SSO support in the issues, I came across https://github.com/anonaddy/anonaddy/issues/248#issuecomment-1407264756 where is being discussed to support proxy authentication like oauth2-proxy. @Queuecumber would make a PR for this, but I couldn't find it, so I made it myself.

**Changes in this PR**
- Moved redirect logic from `LoginController` to helper class.
- Moved user creation logic from `RegisterController` helper class.
- Added config/env entries for:
    - enabling proxy (`use_proxy_authentication` and `ANONADDY_USE_PROXY_AUTHENTICATION`).
    - User header naming (`proxy_authentication_username_header` and `ANONADDY_PROXY_AUTHENTICATION_NAME_HEADER`).
    - Email header naming (`proxy_authentication_email_header` and `ANONADDY_PROXY_AUTHENTICATION_EMAIL_HEADER`).
-  Added Middleware `ProxyAuthentication`.
- Added  `ProxyAuthenticationTest` for testing the middleware.

**Proxy Authentication flow**
- Check if proxy is enabled, if not; go to next middleware.
- Check if currently logged in (using proxy or normal login flow).
- If there is a change (other proxy user, normal flow to proxy flow or no proxy headers anymore), the current user is logged out.
- If there are headers provided.
    - create user when not in db.
    - login.
 - if logged in, redirect to right location.
 - if logged out, redirect to login page.
 - else go to next middleware.