### PR TITLE
allow semver updates for WebAuthn dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -8,7 +8,7 @@
     "license": "AGPL-3.0-or-later",
     "require": {
         "php": "^8.2",
-        "asbiin/laravel-webauthn": "5.0.1",
+        "asbiin/laravel-webauthn": "^5.0.1",
         "bacon/bacon-qr-code": "^3.0",
         "chillerlan/php-qrcode": "^5.0",
         "guzzlehttp/guzzle": "^7.2",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "e4f39c3ee2001ad4826be6d9119ed817",
+    "content-hash": "27035639f3e3398333d54aca5e25b547",
     "packages": [
         {
             "name": "asbiin/laravel-webauthn",


### PR DESCRIPTION
relates to https://github.com/anonaddy/anonaddy/actions/runs/25280961822/job/74118064634#step:4:12

```
./composer.json is valid, but with a few warnings
See https://getcomposer.org/doc/04-schema.md for details on the schema
# General warnings
- require.asbiin/laravel-webauthn : exact version constraints (5.0.1) should be avoided if the package follows semantic versioning
Error: Process completed with exit code 1.
```

Composer treats exact semantic version constraints as warnings, and `composer validate --strict --no-check-publish` promotes that warning to a failing exit code in ci.

cc @willbrowningme 