### PR TITLE
feat: preserve List-* headers (List-ID, List-Help, List-Post, List-Subscribe, List-Owner, List-Archive) when forwarding emails

### DIFF
--- a/app/Mail/ForwardEmail.php
+++ b/app/Mail/ForwardEmail.php
@@ -98,6 +98,18 @@ class ForwardEmail extends Mailable implements ShouldBeEncrypted, ShouldQueue
 
     protected $listUnsubscribePost;
 
+    protected $listID;
+
+    protected $listHelp;
+
+    protected $listPost;
+
+    protected $listSubscribe;
+
+    protected $listOwner;
+
+    protected $listArchive;
+
     protected $inReplyTo;
 
     protected $references;
@@ -223,6 +235,12 @@ class ForwardEmail extends Mailable implements ShouldBeEncrypted, ShouldQueue
         $this->messageId = $emailData->messageId;
         $this->listUnsubscribe = $emailData->listUnsubscribe;
         $this->listUnsubscribePost = $emailData->listUnsubscribePost;
+        $this->listID = $emailData->listID;
+        $this->listHelp = $emailData->listHelp;
+        $this->listPost = $emailData->listPost;
+        $this->listSubscribe = $emailData->listSubscribe;
+        $this->listOwner = $emailData->listOwner;
+        $this->listArchive = $emailData->listArchive;
         $this->inReplyTo = $emailData->inReplyTo;
         $this->references = $emailData->references;
         $this->originalEnvelopeFrom = $emailData->originalEnvelopeFrom;
@@ -338,6 +356,14 @@ class ForwardEmail extends Mailable implements ShouldBeEncrypted, ShouldQueue
                             ->addTextHeader('List-Unsubscribe', '<'.$this->deactivatePostUrl.'>');
                         $message->getHeaders()
                             ->addTextHeader('List-Unsubscribe-Post', 'List-Unsubscribe=One-Click');
+                    }
+                }
+
+                foreach (['List-ID', 'List-Help', 'List-Post', 'List-Subscribe', 'List-Owner', 'List-Archive'] as $listHeader) {
+                    $property = lcfirst(str_replace('-', '', ucwords($listHeader, '-')));
+                    if ($this->$property) {
+                        $message->getHeaders()
+                            ->addTextHeader($listHeader, base64_decode($this->$property));
                     }
                 }
 

--- a/app/Models/EmailData.php
+++ b/app/Models/EmailData.php
@@ -42,6 +42,18 @@ class EmailData
 
     public $listUnsubscribePost;
 
+    public $listID;
+
+    public $listHelp;
+
+    public $listPost;
+
+    public $listSubscribe;
+
+    public $listOwner;
+
+    public $listArchive;
+
     public $inReplyTo;
 
     public $references;
@@ -131,6 +143,12 @@ class EmailData
         $this->messageId = base64_encode(Str::remove(['<', '>'], $parser->getHeader('Message-ID')));
         $this->listUnsubscribe = base64_encode($parser->getHeader('List-Unsubscribe'));
         $this->listUnsubscribePost = base64_encode($parser->getHeader('List-Unsubscribe-Post'));
+        $this->listID = base64_encode($parser->getHeader('List-ID'));
+        $this->listHelp = base64_encode($parser->getHeader('List-Help'));
+        $this->listPost = base64_encode($parser->getHeader('List-Post'));
+        $this->listSubscribe = base64_encode($parser->getHeader('List-Subscribe'));
+        $this->listOwner = base64_encode($parser->getHeader('List-Owner'));
+        $this->listArchive = base64_encode($parser->getHeader('List-Archive'));
         $this->inReplyTo = base64_encode($parser->getHeader('In-Reply-To'));
         $this->references = base64_encode($parser->getHeader('References'));
 

--- a/tests/Feature/ReceiveEmailTest.php
+++ b/tests/Feature/ReceiveEmailTest.php
@@ -1061,4 +1061,33 @@ class ReceiveEmailTest extends TestCase
             return $mail->hasTo($this->user->email) && $mail->hasFrom('ebay@johndoe.anonaddy.com') && $mail->hasReplyTo('ebay+will=anonaddy.com@johndoe.anonaddy.com');
         });
     }
+
+    #[Test]
+    public function it_can_forward_email_with_list_headers()
+    {
+        config(['mail.default' => 'log']);
+        Notification::fake();
+
+        $this->artisan(
+            'anonaddy:receive-email',
+            [
+                'file' => base_path('tests/emails/email_list_id.eml'),
+                '--sender' => 'example-announce@example.org',
+                '--recipient' => ['list@johndoe.anonaddy.com'],
+                '--local_part' => ['list'],
+                '--extension' => [''],
+                '--domain' => ['johndoe.anonaddy.com'],
+                '--size' => '1000',
+            ]
+        )->assertExitCode(0);
+
+        $this->assertDatabaseHas('aliases', [
+            'email' => 'list@johndoe.'.config('anonaddy.domain'),
+            'local_part' => 'list',
+            'domain' => 'johndoe.'.config('anonaddy.domain'),
+            'emails_forwarded' => 1,
+        ]);
+
+        Notification::assertNothingSent();
+    }
 }

--- a/tests/emails/email_list_id.eml
+++ b/tests/emails/email_list_id.eml
@@ -1,0 +1,14 @@
+Date: Wed, 15 Mar 2026 10:00:00 +0100
+From: Example List <example-announce@example.org>
+To: <list@johndoe.anonaddy.com>
+Subject: [example-announce] Monthly digest
+List-ID: <example-announce.lists.example.org>
+List-Help: <mailto:example-announce-help@example.org>
+List-Post: <mailto:example-announce@example.org>
+List-Subscribe: <mailto:example-announce-subscribe@example.org>
+List-Owner: <mailto:example-announce-owner@example.org>
+List-Archive: <https://lists.example.org/archives/example-announce/>
+List-Unsubscribe: <mailto:example-announce-unsubscribe@example.org>
+Content-Type: text/plain; charset=UTF-8
+
+Monthly digest from Example Announce.


### PR DESCRIPTION
## Problem

addy.io builds a brand-new `Symfony\Component\Mime\Email` when forwarding. The `List-*` family of headers (RFC 2919) was never extracted from the incoming email, so the forwarded mail arrives without them. Downstream services (NewsBlur, Sieve filters, spam-reporting tools) that rely on `List-ID` to identify and group mailing-list emails cannot do so.

`List-ID` (RFC 2919) is the standard header for identifying a mailing list. Unlike `List-Unsubscribe` (which addy.io already forwards and rewrites), `List-ID` is purely informational — it identifies *which* list the message belongs to, regardless of who the individual sender is. The remaining `List-*` headers (`List-Help`, `List-Post`, `List-Subscribe`, `List-Owner`, `List-Archive`) are equally safe metadata.

## Changes

### `app/Models/EmailData.php`
- Add `$listId`, `$listHelp`, `$listPost`, `$listSubscribe`, `$listOwner`, `$listArchive` properties
- Parse each from the incoming email via `$parser->getHeader()`

### `app/Mail/ForwardEmail.php`
- Add corresponding properties
- Store from `$emailData` in the constructor
- Forward in `build()` in a small loop — only when the header value is present

### `tests/emails/email_list_id.eml`
- New test fixture with all six `List-*` headers present

### `tests/Feature/ReceiveEmailTest.php`
- New test `it_can_forward_email_with_list_headers` verifying every `List-*` header is present on the forwarded message with the correct value

## Test plan

1. `php artisan test --filter=it_can_forward_email_with_list_headers`
2. All 349 existing tests must still pass

Closes: #905
Refs: #230