### PR TITLE
Added a route for starting record validation for a given domain to API

### DIFF
--- a/routes/api.php
+++ b/routes/api.php
@@ -38,6 +38,7 @@ use App\Http\Controllers\Api\UsernameDefaultRecipientController;
 use App\Http\Controllers\Auth\ApiAuthenticationController;
 use App\Http\Controllers\BlocklistCheckController;
 use App\Http\Controllers\RecipientVerificationController;
+use App\Http\Controllers\DomainVerificationController;
 use Illuminate\Support\Facades\Route;
 
 /*
@@ -237,4 +238,6 @@ Route::group([
     Route::get('api-token-details', [ApiTokenDetailController::class, 'show']);
 
     Route::get('/chart-data', [ChartDataController::class, 'index']);
+
+    Route::get('/domains/{id}/check-sending', [DomainVerificationController::class, 'checkSending']);
 });


### PR DESCRIPTION
For my domain management software I needed a way to start the validation in my addy.io instance after DNS changes.

This simple patch adds a route to the API to start the validation.